### PR TITLE
Update roundTripper in sqlitehttpcli.go to support file:// URIs

### DIFF
--- a/sqlitehttpcli/sqlitehttpcli.go
+++ b/sqlitehttpcli/sqlitehttpcli.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"path/filepath"
 
 	_ "github.com/mattn/go-sqlite3"
 	"github.com/psanford/sqlite3vfs"
@@ -97,5 +98,15 @@ func (rt *roundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 		req.Header.Set("User-Agent", rt.userAgent)
 	}
 
-	return http.DefaultTransport.RoundTrip(req)
+	tr := http.DefaultTransport
+
+	if req.URL.Scheme == "file" {
+		path := req.URL.Path
+		root := filepath.Dir(path)
+		base := filepath.Base(path)
+		tr = http.NewFileTransport(http.Dir(root))
+		req.URL.Path = base
+	}
+
+	return tr.RoundTrip(req)
 }


### PR DESCRIPTION
For example:

```
> ~/go/bin/go1.17rc2 run sqlitehttpcli/sqlitehttpcli.go -url file:///usr/local/data/sfomuseum-architecture.db -query 'SELECT id FROM geojson LIMIT 10'
row: [1159157037]
row: [1159157039]
row: [1159157041]
row: [1159157045]
row: [1159157047]
row: [1159157049]
row: [1159157051]
row: [1159157053]
row: [1159157055]
row: [1159157057]
```

I considered moving `roundTripper` in to its own public-facing package but decided against it for this PR. "One thing at a time" and all that :-)