### PR TITLE
Improve gh workflow logic

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -22,15 +22,10 @@ jobs:
       uses: actions/checkout@v1
 
     - name: Build
-      run: go build -v .
+      run: go build -v ./...
 
     - name: Build extension
       run: make -C sqlite3http-ext
-
-    - name: Build cli tool
-      run: |
-        cd sqlitehttpcli
-        go build -v .
 
     - name: Test
       run: go test -v . --timeout 60s

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
-httpvfs.so
-sqlite3http_ext.a
+sqlitehttpcli/sqlitehttpcli
+sqlite3http-ext/httpvfs.so
+sqlite3http-ext/sqlite3http_ext.a

--- a/sqlite3http-ext/sqlite3http_ext.go
+++ b/sqlite3http-ext/sqlite3http_ext.go
@@ -1,3 +1,6 @@
+//go:build SQLITE3VFS_LOADABLE_EXT
+// +build SQLITE3VFS_LOADABLE_EXT
+
 package main
 
 // import C is necessary for us to export SqliteHTTPRegister in the c-archive .a file


### PR DESCRIPTION
Use the same build tag that sqlite3vfs uses for extension builds for
the loadable module. This allows us to ignore this package for normal
builds via `go build ./...`.